### PR TITLE
fix: Wrap SetupWizard in BrowserRouter

### DIFF
--- a/admin-web/src/App.js
+++ b/admin-web/src/App.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { BrowserRouter } from 'react-router-dom';
 import api from './services/api';
 import Routes from './routes';
 import SetupWizard from './pages/Setup';
@@ -24,7 +25,7 @@ function AppLoader() {
     return <div>Carregando...</div>;
   }
 
-  return isSetupComplete ? <Routes /> : <Layout><SetupWizard /></Layout>;
+  return isSetupComplete ? <Routes /> : <BrowserRouter><Layout><SetupWizard /></Layout></BrowserRouter>;
 }
 
 function App() {


### PR DESCRIPTION
This change fixes the "Invariant failed: You should not use <Link> outside a <Router>" error by wrapping the `SetupWizard` component in a `BrowserRouter`. This ensures that the `Link` components within the `Layout` have access to the router context.