### PR TITLE
fix: Fix "Cannot access 'loadData' before initialization" error in Ki…

### DIFF
--- a/admin-web/src/pages/Kiosk/index.js
+++ b/admin-web/src/pages/Kiosk/index.js
@@ -9,29 +9,6 @@ export default function Kiosk() {
   const [lastConsumed, setLastConsumed] = useState(null);
   const [isPaused, setIsPaused] = useState(false);
   const [manualBarcode, setManualBarcode] = useState('');
-  const processConsumption = useCallback(async (barcode) => {
-    if (!barcode || isPaused) return;
-
-    setIsPaused(true);
-    try {
-      const token = localStorage.getItem('token');
-      const response = await api.post(
-        '/consumptions',
-        { barcode },
-        { headers: { Authorization: `Bearer ${token}` } }
-      );
-      setLastConsumed({ product: response.data.product, status: 'success' });
-      loadData();
-    } catch (error) {
-      const errorMessage = error.response?.data?.error || 'Erro desconhecido';
-      setLastConsumed({ product: { name: errorMessage }, status: 'error' });
-    } finally {
-      setTimeout(() => {
-        setLastConsumed(null);
-        setIsPaused(false);
-      }, 3000);
-    }
-  }, [isPaused, loadData]);
 
   const loadData = useCallback(async () => {
     const token = localStorage.getItem('token');
@@ -60,6 +37,30 @@ export default function Kiosk() {
     }
 
   }, []);
+
+  const processConsumption = useCallback(async (barcode) => {
+    if (!barcode || isPaused) return;
+
+    setIsPaused(true);
+    try {
+      const token = localStorage.getItem('token');
+      const response = await api.post(
+        '/consumptions',
+        { barcode },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setLastConsumed({ product: response.data.product, status: 'success' });
+      loadData();
+    } catch (error) {
+      const errorMessage = error.response?.data?.error || 'Erro desconhecido';
+      setLastConsumed({ product: { name: errorMessage }, status: 'error' });
+    } finally {
+      setTimeout(() => {
+        setLastConsumed(null);
+        setIsPaused(false);
+      }, 3000);
+    }
+  }, [isPaused, loadData]);
 
   useEffect(() => {
     loadData();


### PR DESCRIPTION
…osk component

This change fixes a `ReferenceError` in the `Kiosk` component by moving the `loadData` function definition before the `processConsumption` function definition. This ensures that `loadData` is defined before it is called within `processConsumption`.